### PR TITLE
Enhance `AxError`

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,7 +10,7 @@ macro_rules! template {
 
 /// Linux specific error codes defined in `errno.h`.
 #[repr(i32)]
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum LinuxError {{
 {0}\
 }}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,7 +221,7 @@ macro_rules! ax_err {
 /// Throws an error of type [`AxError`] with the given error code, optionally
 /// with a message.
 #[macro_export]
-macro_rules! bail {
+macro_rules! ax_bail {
     ($($t:tt)*) => {
         return $crate::ax_err!($($t)*);
     };


### PR DESCRIPTION
This PR adds more variants to `AxError`, allows conversion between `AxError` and `LinuxError`, adds `ax_bail` macro to raise an `AxError`.